### PR TITLE
Update Go version in Dockerfile for backend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # ビルド成果物は /app/frontend/dist に作成される
 
 # ステージ2: Goビルドステージ (バックエンド)
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.24-alpine AS go-builder
 
 WORKDIR /app
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/linkalls/fast-memos/database"
 	"github.com/linkalls/fast-memos/handlers"
 
-	"github.com/gofiber/contrib/cors" // CORSミドルウェアをインポート
+	"github.com/gofiber/fiber/v2/middleware/cors" // 正しいCORSミドルウェアのインポートパス
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"


### PR DESCRIPTION
- Changed the Go version in the `go-builder` stage of the Dockerfile from `golang:1.22-alpine` to `golang:1.24-alpine`.
- This aligns the Docker build environment with the Go version specified in `go.mod` (go 1.24.3), resolving the `go mod download` error during Docker build.